### PR TITLE
Fix #2 Loading words into memory throws StackOverflowError

### DIFF
--- a/src/main/kotlin/zanagram/App.kt
+++ b/src/main/kotlin/zanagram/App.kt
@@ -1,18 +1,42 @@
 package zanagram
 
 import java.io.File
+import kotlin.system.measureTimeMillis
 
 class Node<T>(val data: T, val next: Node<T>?)
 
-fun <T> add(data: T, node: Node<T>?): Node<T> =
-    if (node == null) Node(data, null)
-    else Node(node.data, add(data, node.next))
+fun <T> add(data: T, node: Node<T>?): Node<T>? =
+    add(data, node, null)
 
-fun <T> size(node: Node<T>?): Int =
-    if (node == null) 0 else 1 + size(node.next)
+tailrec fun <T> add(
+    data: T, node: Node<T>?, acc: Node<T>?
+): Node<T>? =
+    if (node == null) reverse(Node(data, acc))
+    else add(data, node.next, Node(node.data, acc))
+
+fun <T> reverse(node: Node<T>?): Node<T>? =
+    reverse(node, null)
+
+tailrec fun <T> reverse(
+    node: Node<T>?, acc: Node<T>?
+): Node<T>? =
+    if (node == null) acc
+    else reverse(node.next, Node(node.data, acc))
+
+fun <T> size(node: Node<T>?): Int = size(node, 0)
+
+tailrec fun <T> size(node: Node<T>?, acc: Int): Int =
+    if (node == null) acc else size(node.next, 1 + acc)
 
 fun main(args: Array<String>) {
     var list: Node<String>? = null
-    File("words_alpha.txt").forEachLine { list = add(it, list) }
-    println("Number of words: ${size(list)}")
+    val timeToLoad = measureTimeMillis {
+        File("words_alpha.txt").forEachLine { list = add(it, list) }
+    }
+    var size = 0
+    val timeToSize = measureTimeMillis { size = size(list) }
+
+    println("Time to load: $timeToLoad")
+    println("Time to size: $timeToSize")
+    println("Number of words: $size")
 }

--- a/src/test/kotlin/zanagram/AppTest.kt
+++ b/src/test/kotlin/zanagram/AppTest.kt
@@ -19,6 +19,31 @@ class AppTest {
     }
 
     @Test
+    fun `add twice makes size equal 2`() {
+        var list: Node<Int>? = null
+        list = add(1, list)
+        list = add(2, list)
+
+        val size = size(list)
+
+        assertEquals(2, size)
+    }
+
+    @Test
+    fun `add adds to the end`() {
+        var list: Node<Int>? = null
+
+        list = add(1, list)
+        list = add(2, list)
+
+        val first = list!!.data
+        val second = list.next!!.data
+
+        assertEquals(1, first)
+        assertEquals(2, second)
+    }
+
+    @Test
     fun `size of empty list is zero`() {
         var list: Node<Int>? = null
 


### PR DESCRIPTION
By using tail recursion we don't have a StackOverflowError anymore.
Loading the words takes too long, this should be another issue.
