### PR TITLE
Fix #5 Loading the words is too slow.

### DIFF
--- a/src/main/kotlin/zanagram/App.kt
+++ b/src/main/kotlin/zanagram/App.kt
@@ -5,13 +5,7 @@ import kotlin.system.measureTimeMillis
 
 class Node<T>(val data: T, var next: Node<T>?)
 
-fun <T> add(data: T, node: Node<T>?): Node<T> {
-    if (node == null) return Node(data, null)
-    var n = node
-    while (n!!.next != null) n = n.next
-    n.next = Node(data, null)
-    return node
-}
+fun <T> add(data: T, node: Node<T>?): Node<T> = Node(data, node)
 
 fun <T> size(node: Node<T>?): Int {
     if (node == null) return 0

--- a/src/test/kotlin/zanagram/AppTest.kt
+++ b/src/test/kotlin/zanagram/AppTest.kt
@@ -27,7 +27,7 @@ class AppTest {
     }
 
     @Test
-    fun `add adds to the end`() {
+    fun `add adds to the beginning`() {
         var list: Node<Int>? = null
 
         list = add(1, list)
@@ -36,8 +36,8 @@ class AppTest {
         val first = list!!.data
         val second = list.next!!.data
 
-        assertEquals(1, first)
-        assertEquals(2, second)
+        assertEquals(2, first)
+        assertEquals(1, second)
     }
 
     @Test


### PR DESCRIPTION
By adding to the beginning of the beginning of the list instead of at the end the loading time is much faster because we change the loading from O(n^2) to just O(n).

```
Time to load: 332
Time to size: 8
Number of words: 370104
```